### PR TITLE
Added support to WebApp to be ran directly.

### DIFF
--- a/WebApp/Properties/launchSettings.json
+++ b/WebApp/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:27904/",
+      "applicationUrl": "http://localhost:8001/",
       "sslPort": 0
     }
   },
@@ -15,10 +15,10 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "WebApp": {
+    "NoFabric": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000",
+      "launchUrl": "http://localhost:8001/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/WebApp/StartupDevelopment.cs
+++ b/WebApp/StartupDevelopment.cs
@@ -11,14 +11,16 @@ using WebApp.Services;
 
 namespace WebApp
 {
-    public class Startup
+    public class StartupDevelopment
     {
-        public Startup(IHostingEnvironment env)
+        public StartupDevelopment(IHostingEnvironment env)
         {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+            var builder = new ConfigurationBuilder().SetBasePath(env.ContentRootPath)
+                                                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                                                    .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+
+            // For more details on using the user secret store see http://go.microsoft.com/fwlink/?LinkID=532709
+            builder.AddUserSecrets();
 
             builder.AddEnvironmentVariables();
             Configuration = builder.Build();
@@ -29,8 +31,6 @@ namespace WebApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddServiceFabricService<WebAppService>();
-
             // Add framework services.
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
@@ -52,7 +52,9 @@ namespace WebApp
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            app.UseExceptionHandler("/Home/Error");
+            app.UseDeveloperExceptionPage();
+            app.UseDatabaseErrorPage();
+            app.UseBrowserLink();
 
             app.UseStaticFiles();
 

--- a/WebApp/project.json
+++ b/WebApp/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "userSecretsId": "aspnet-WebApp-4b332dff-6daa-4b2c-a482-ddbf5b11741d",
 
   "dependencies": {
@@ -11,6 +11,7 @@
       "version": "1.0.0-preview1-final",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
     "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-rc2-final",

--- a/WebApp/web.config
+++ b/WebApp/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" />
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Added support to WebApp to be ran directly without having to deploy to Service Fabric.  Set WebApp as StartUp Project and NoFabric as Launch Profile and Run.  I've found this to be a useful step for my projects.  The compilation and deployment of large projects to service project can be time consuming and slow down severely normal debugging.  In this way someone can develop the WebApp very quickly and switch to deploying the full application suite to Service Fabric.
